### PR TITLE
add loading translation text domain

### DIFF
--- a/crisp.php
+++ b/crisp.php
@@ -13,6 +13,14 @@
  * Domain Path: /languages/
 */
 
+add_action( 'plugins_loaded', 'crisp_load_textdomain' );
+/**
+ * Load plugin textdomain.
+ */
+function crisp_load_textdomain() {
+   load_plugin_textdomain( 'crisp', false, basename( dirname( __FILE__ ) ) . '/languages' );
+}
+
 add_action('admin_menu', 'crisp_create_menu');
 
 function crisp_create_menu() {


### PR DESCRIPTION
Loads the plugin's translated strings.
https://codex.wordpress.org/Function_Reference/load_plugin_textdomain